### PR TITLE
fix: add visible ::selection highlight for dark mode

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -18,6 +18,11 @@ function applyDarkMode() {
       .qj, .aEe  {
       filter: invert(1) hue-rotate(180deg) !important;
       }
+
+      ::selection {
+        background:rgb(0, 0, 0) !important;
+        color: rgb(255, 255, 255) !important;
+      }
     `;
   document.head.appendChild(style);
 }


### PR DESCRIPTION
  ## What
  Adds a ::selection CSS rule to ensure highlighted text is visible in dark mode.

  ## Why
  Previously, highlighted text was invisible when using dark mode due to lack of custom selection styling. This improves accessibility and user experience.

  ## How
  Injects the following CSS when dark mode is active:
```
  ::selection {
    background: rgb(0, 0, 0) !important;
    color: rgb(255, 255, 255) !important;
  }
```

  ## Testing
  - Load the extension, enable dark mode, and select text in Gmail. The selection should now be clearly visible.