### PR TITLE
Fix CSS parse error, idempotency bug, and remove unused manifest entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,22 @@ i.e. When your browser is on dark mode, your Gmail page turns to dark mode. Othe
 
 Setup Instructions:
 
-1 - Download the extension from the gitHub page and unzip the file
+1 - Download the extension from the GitHub page and unzip the file
 
 2 - Open "Manage extensions" on your browser
 
-3 - Turn on "Develeper Mode"
+3 - Turn on "Developer Mode"
 
 4 - Click on "Load Unpacked"
 
 5 - Select the extension folder
 
-6 - Make sure is the extension toggle is On
+6 - Make sure the extension toggle is On
 
 7 - Open Gmail and see if it worked
 
 
-Disclamers:
+Disclaimers:
 - This extension (probably) won't work with browsers that don't use Chromium.
 - This extension works by inverting colors, so if your Gmail page has images on the background, this extension inverts those colors too,
 (don't worry about the images of emails, profile images and label colors, those aren't inverted)

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,62 +1,22 @@
 // Function to apply dark mode styles to Gmail
 function applyDarkMode() {
+  if (document.getElementById("dark-mode-style")) return;
   const style = document.createElement("style");
   style.id = "dark-mode-style";
-  style.innerHTML = `
+  style.textContent = `
       html {
         filter: invert(.94) hue-rotate(180deg);
         background: #121212 !important;
       }
-
-      // img, div  {
-      //   filter: invert(1.06) hue-rotate(180deg) !important;;
-      // }
-
-
-      // img, video, picture, canvas {
-      //   filter: invert(1) hue-rotate(180deg);
-      // }
-
-
-      // /* For the circle around the profile picture */
-      // .gb_P {
-      //   filter: invert(1) hue-rotate(180deg);
-      }
-
-      // /* applications on the right side of the window (Keep, Calendar, ... etc.) */
-      // div.aT5-aOt-I-JX-Jw {
-      //   filter: invert(1) hue-rotate(180deg);
-      // }
-
-      // img.HiaYvf-SmKAyb {
-      //   filter: invert(1) hue-rotate(180deg);
-      // }
-
-      // div.qj.aEe {
-      //   filter: invert(1) hue-rotate(180deg);
-      // }
-
-
-      // la-s, la-c, la-e, la-l, la-m, la-r {
-      //   filter: invert(1) hue-rotate(180deg);
-      // }
-
 
       img, video, picture, canvas {
         filter: invert(1) hue-rotate(180deg);
       }
 
       /* For the circle around the profile picture */
-      .gb_P {
+      .gb_P, .gb_T {
         filter: invert(1) hue-rotate(180deg);
       }
-
-
-      /* For the circle around the profile picture */
-      .gb_T {
-        filter: invert(1) hue-rotate(180deg);
-      }
-
 
       /* applications on the right side of the window (Keep, Calendar, ... etc.) */
       div.aT5-aOt-I-JX-Jw {
@@ -70,7 +30,6 @@ function applyDarkMode() {
       div.qj.aEe{
         filter: invert(1) hue-rotate(180deg);
       }
-
 
       div.at{
         filter: invert(1) hue-rotate(180deg);
@@ -87,10 +46,7 @@ function applyDarkMode() {
 
 // Function to remove dark mode styles from Gmail
 function removeDarkMode() {
-  const existingStyle = document.getElementById("dark-mode-style");
-  if (existingStyle) {
-    existingStyle.remove();
-  }
+  document.getElementById("dark-mode-style")?.remove();
 }
 
 // Check for system dark mode

--- a/manifest.json
+++ b/manifest.json
@@ -3,10 +3,6 @@
     "name": "Gmail Dark Mode Toggle",
     "version": "1.0",
     "description": "Automatically switches Gmail between dark and light mode based on system settings.",
-    "permissions": [
-      "activeTab",
-      "scripting"
-    ],
     "content_scripts": [
     {
         "matches": ["https://mail.google.com/*"],
@@ -14,9 +10,6 @@
         "run_at": "document_idle"
     }
     ],
-    "background": {
-      "service_worker": "background.js"
-    },
     "action": {
       "default_popup": "popup.html"
     },


### PR DESCRIPTION
Four changes: two bug fixes, two manifest cleanups, and minor code tidying.

**CSS parse error (contentScript.js, lines 11–43)**

The commented-out block uses JS `//` syntax inside a CSS template literal. CSS has no `//` comment syntax, so those lines are injected verbatim into the DOM as stylesheet text. The closing `}` on line 24 was not commented out; it lands in the injected stylesheet as a bare `}` with no matching opening brace. The injected stylesheet is invalid. Browsers recover, but parsers vary in their recovery behavior.

Fix: delete the commented-out block.

**Idempotency (applyDarkMode)**

`applyDarkMode()` has no guard against being called more than once. If the function is triggered from multiple paths – initial load, the `matchMedia` listener, and any future caller – a second `<style id="dark-mode-style">` element is appended to `document.head`. DOM IDs must be unique; `getElementById()` returns only the first match. The second node stays in the DOM and cannot be removed by `removeDarkMode()`, leaking styles for the remainder of the page session.

Fix: return early if the element already exists.

**Unused manifest permissions**

`activeTab` and `scripting` are required only for programmatic injection via `chrome.scripting.executeScript()`. This extension uses declarative content scripts (`content_scripts` key), which require neither permission. Unused declared permissions expand the extension's capability surface and trigger additional scrutiny during Web Store review.

Fix: remove both from the `permissions` array.

**Unused background service worker**

`background.js` calls `console.log()` on install. The service worker performs no function for the extension. Declaring a background service worker that does nothing instantiates a worker process on every browser startup for zero benefit.

Fix: remove the `background` key from `manifest.json`. `background.js` is left in the repository.

**Minor cleanup**

- `.gb_P` and `.gb_T` consolidated into a single selector rule (identical declarations).
- `removeDarkMode()` collapsed to one line using optional chaining.
- `style.innerHTML` replaced with `style.textContent`. `<style>` elements contain CSS text; `textContent` is the appropriate property for setting their content.
- README: fixed typos (Develeper, Disclamers, gitHub) and one grammatical error.