### PR TITLE
Add MutationObserver to recover dark mode after SPA navigation

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -110,3 +110,10 @@ updateMode(mediaQuery);
 
 // Listen for changes in the system theme
 mediaQuery.addEventListener('change', updateMode);
+
+// Re-apply if Gmail's SPA navigation removes the injected style
+new MutationObserver(() => {
+  if (mediaQuery.matches && !document.getElementById("dark-mode-style")) {
+    applyDarkMode();
+  }
+}).observe(document.head, { childList: true });


### PR DESCRIPTION
Gmail and its underlying libraries modify `document.head` dynamically during a session (adding and removing `<style>`, `<link>`, and `<meta>` elements). The injected `<style>` is not protected against accidental removal. Without recovery logic, if the element is ever removed while dark mode is active, the mode deactivates silently.

A `MutationObserver` on `document.head` detects structural changes and re-applies the style if it disappears while dark mode is active.

```js
new MutationObserver(() => {
  if (mediaQuery.matches && !document.getElementById("dark-mode-style")) {
    applyDarkMode();
  }
}).observe(document.head, { childList: true });
```

The observer fires only on `childList` changes to `document.head` – it does not watch subtree changes or attributes, so the performance footprint is minimal.